### PR TITLE
Display UID and allow setting by a substring of UID

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,14 @@ switchaudio-osx requires command line tools to be installed from OS X. To instal
 Usage
 -----
 
-SwitchAudioSource [-a] [-c] [-t type] [-n] -s device\_name | -i device\_id 
+SwitchAudioSource [-a] [-c] [-t type] [-n] -s device\_name | -i device\_id | -u device\_uid 
 
  - **-a**               : shows all devices
  - **-c**               : shows current device
  - **-t** _type_        : device type (input/output/system).  Defaults to output.
  - **-n**               : cycles the audio device to the next one
  - **-i** _device_id_   : sets the audio device to the given device by id
+ - **-u** _device_uid_   : sets the audio device to the given device by uid or a substring of the uid
  - **-s** _device_name_ : sets the audio device to the given device by name
 
 

--- a/audio_switch.c
+++ b/audio_switch.c
@@ -31,13 +31,14 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 
 void showUsage(const char * appName) {
-	printf("Usage: %s [-a] [-c] [-t type] [-n] -s device_name | -i device_id\n"
+	printf("Usage: %s [-a] [-c] [-t type] [-n] -s device_name | -i device_id | -u device_uid\n"
            "  -a             : shows all devices\n"
            "  -c             : shows current device\n\n"
            
            "  -t type        : device type (input/output/system).  Defaults to output.\n"
            "  -n             : cycles the audio device to the next one\n"
            "  -i device_id   : sets the audio device to the given device by id\n"
+           "  -u device_uid  : sets the audio device to the given device by uid or a substring of the uid\n"
            "  -s device_name : sets the audio device to the given device by name\n\n",appName);
 }
 
@@ -45,12 +46,13 @@ int runAudioSwitch(int argc, const char * argv[]) {
 	char requestedDeviceName[256];
     char printableDeviceName[256];
     int requestedDeviceID;
+    char requestedDeviceUID[256];
 	AudioDeviceID chosenDeviceID = kAudioDeviceUnknown;
 	ASDeviceType typeRequested = kAudioTypeUnknown;
 	int function = 0;
 
 	int c;
-    while ((c = getopt(argc, (char **)argv, "hacnt:i:s:")) != -1) {
+    while ((c = getopt(argc, (char **)argv, "hacnt:i:s:u:")) != -1) {
 		switch (c) {
 			case 'a':
 				// show all
@@ -76,6 +78,12 @@ int runAudioSwitch(int argc, const char * argv[]) {
 				function = kFunctionSetDeviceByID;
                 requestedDeviceID = atoi(optarg);
 				break;
+
+            case 'u':
+                // set the requestedDeviceUID
+                function = kFunctionSetDeviceByUID;
+                strcpy(requestedDeviceUID, optarg);
+                break;
 
             case 's':
                 // set the requestedDeviceName
@@ -165,6 +173,16 @@ int runAudioSwitch(int argc, const char * argv[]) {
         strcpy(printableDeviceName, requestedDeviceName);
     }
 
+    if (function == kFunctionSetDeviceByUID) {
+        // find the id of the requested device
+        chosenDeviceID = getRequestedDeviceIDFromUIDSubstring(requestedDeviceUID, typeRequested);
+        if (chosenDeviceID == kAudioDeviceUnknown) {
+            printf("Could not find an audio device with UID \"%s\" of type %s.  Nothing was changed.\n", requestedDeviceUID, deviceTypeName(typeRequested));
+            return 1;
+        }
+        sprintf(printableDeviceName, "Device with UID: %s", getDeviceUID(chosenDeviceID));
+    }
+
     if (!chosenDeviceID) {
         printf("Please specify audio device.\n");
         showUsage(argv[0]);
@@ -178,6 +196,64 @@ int runAudioSwitch(int argc, const char * argv[]) {
     return 0;
 }
 
+char * getDeviceUID(AudioDeviceID deviceID) {
+    CFStringRef deviceUID = NULL;
+    UInt32 dataSize = sizeof(deviceUID);
+    AudioObjectPropertyAddress propertyAddress = {
+        kAudioHardwarePropertyDevices,
+        kAudioObjectPropertyScopeGlobal,
+        kAudioObjectPropertyElementMaster
+    };
+    
+    propertyAddress.mSelector = kAudioDevicePropertyDeviceUID;
+    
+    AudioObjectGetPropertyData(deviceID, &propertyAddress, 0, NULL, &dataSize, &deviceUID);
+            
+    char * deviceUID_string = CFStringGetCStringPtr(deviceUID, kCFStringEncodingASCII);
+    
+    CFRelease(deviceUID);
+    
+    return deviceUID_string;
+}
+
+
+AudioDeviceID getRequestedDeviceIDFromUIDSubstring(char * requestedDeviceUID, ASDeviceType typeRequested) {
+    UInt32 propertySize;
+    AudioDeviceID dev_array[64];
+    int numberOfDevices = 0;
+
+    AudioHardwareGetPropertyInfo(kAudioHardwarePropertyDevices, &propertySize, NULL);
+    // printf("propertySize=%d\n",propertySize);
+
+    AudioHardwareGetProperty(kAudioHardwarePropertyDevices, &propertySize, dev_array);
+    numberOfDevices = (propertySize / sizeof(AudioDeviceID));
+    // printf("numberOfDevices=%d\n",numberOfDevices);
+
+    for(int i = 0; i < numberOfDevices; ++i) {
+        switch(typeRequested) {
+            case kAudioTypeInput:
+                if (!isAnInputDevice(dev_array[i])) continue;
+                break;
+
+            case kAudioTypeOutput:
+                if (!isAnOutputDevice(dev_array[i])) continue;
+                break;
+
+            case kAudioTypeSystemOutput:
+                if (getDeviceType(dev_array[i]) != kAudioTypeOutput) continue;
+                break;
+            default: break;
+        }
+
+        char * deviceUID = getDeviceUID(dev_array[i]);
+        
+        if (strstr(deviceUID, requestedDeviceUID) != NULL) {
+            return dev_array[i];
+        }
+    }
+
+    return kAudioDeviceUnknown;
+}
 
 AudioDeviceID getCurrentlySelectedDeviceID(ASDeviceType typeRequested) {
 	UInt32 propertySize;
@@ -259,7 +335,7 @@ void showCurrentlySelectedDeviceID(ASDeviceType typeRequested) {
 	
 	currentDeviceID = getCurrentlySelectedDeviceID(typeRequested);
 	getDeviceName(currentDeviceID, currentDeviceName);
-	printf("%s\n",currentDeviceName);
+	printf("%s (ID: %u) (UID: %s)\n", currentDeviceName, currentDeviceID, getDeviceUID(currentDeviceID));
 }
 
 
@@ -397,6 +473,6 @@ void showAllDevices(ASDeviceType typeRequested) {
 		}
 		
 		getDeviceName(dev_array[i], deviceName);
-        printf("\"%s\" (ID: %u) (%s)\n", deviceName, dev_array[i], deviceTypeName(device_type));
+        printf("\"%s\" (ID: %u) (UID: %s) (%s)\n", deviceName, dev_array[i], getDeviceUID(dev_array[i]), deviceTypeName(device_type));
 	}
 }

--- a/audio_switch.h
+++ b/audio_switch.h
@@ -47,13 +47,16 @@ enum {
 	kFunctionShowAll         = 3,
 	kFunctionShowCurrent     = 4,
 	kFunctionCycleNext       = 5,
-    kFunctionSetDeviceByID   = 6
+    kFunctionSetDeviceByID   = 6,
+    kFunctionSetDeviceByUID  = 7
 };
 
 
 
 void showUsage(const char * appName);
 int runAudioSwitch(int argc, const char * argv[]);
+char * getDeviceUID(AudioDeviceID deviceID);
+AudioDeviceID getRequestedDeviceIDFromUIDSubstring(char * requestedDeviceUID, ASDeviceType typeRequested);
 AudioDeviceID getCurrentlySelectedDeviceID(ASDeviceType typeRequested);
 void getDeviceName(AudioDeviceID deviceID, char * deviceName);
 ASDeviceType getDeviceType(AudioDeviceID deviceID);


### PR DESCRIPTION
The device ID is not consistent when unplugging and re-plugging an external audio source (it is some sort of counter). So this presents a problem when you want to choose a specific device.

macOS exposes a UID string for each audio device. The format of this string is a black box. For example, for built-in devices it is a simple string like `BuiltInSpeakerDevice`, but for a DisplayPort device it may be something like `AppleGFXHDAEngineOutputDP:30001:0:{AD19-43B2-5257260B}`. In the second case, the same device may appear as `AppleGFXHDAEngineOutputDP:30001:1:{AD19-43B2-5257260B}` if it is the second DisplayPort device currently plugged in.

So to support switching inputs by UID, this PR checks against a substring and it is left to the user to find the unique portion of the string. For the above example, running `SwitchAudioSource -u AD19-43B2-5257260B` always selects the appropriate device.